### PR TITLE
Improvements and bugfixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ language: python
 python:
     - "2.7"
     - "3.4"
+    - "3.5"
+    - "3.6"
     - "pypy"
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,7 @@ install:
 script:
     # run tests
     - make test
+
+addons:
+  apt_packages:
+    - pandoc

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Delete unused media files from Django project
 
 [![build-status-image]][travis]
-[![coverage-status-image]][codecov]
 
 This package provides management command `cleanup_unused_media` for Django applications. With help of this management command you can remove all media files which are no longer used (files without references from any Django model with `FileField` or `ImageField` fields or their inheritances).
 
@@ -12,9 +11,9 @@ This package provides management command `cleanup_unused_media` for Django appli
     pip install django-unused-media
     ```
 
-    Python 2.7, 3.5, PyPy are tested with tox.
+    Python 2.7, 3.5, 3.6, PyPy are tested with tox.
     
-    Django 1.6, 1.7, 1.8, 1.9, 1.10 are tested with tox.
+    Django 1.6, 1.7, 1.8, 1.9, 1.10, 1.11 are tested with tox.
 
 2.  Add ``django-unused-media`` to ``INSTALLED_APPS``:
     ```python
@@ -73,3 +72,6 @@ make test
 
 # License
 [MIT licence](./LICENSE)
+
+[build-status-image]: https://api.travis-ci.org/vartagg/django-unused-media.svg?branch=master
+[travis]: http://travis-ci.org/vartagg/django-unused-media?branch=master

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Delete unused media files from Django project
 
+[![build-status-image]][travis]
+[![coverage-status-image]][codecov]
+
 This package provides management command `cleanup_unused_media` for Django applications. With help of this management command you can remove all media files which are no longer used (files without references from any Django model with `FileField` or `ImageField` fields or their inheritances).
 
 # Installation

--- a/django_unused_media/management/commands/cleanup_unused_media.py
+++ b/django_unused_media/management/commands/cleanup_unused_media.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from django.conf import settings
 from django.core.management.base import BaseCommand
 import six.moves
 
@@ -27,6 +26,12 @@ class Command(BaseCommand):
                             default=[],
                             help='Exclude files by mask (only * is supported), can use multiple --exclude')
 
+        parser.add_argument('-r', '--remove-empty-dirs',
+                            dest='remove_empty_dirs',
+                            action='store_false',
+                            default=False,
+                            help='Remove empty dirs after files cleanup')
+
     def handle(self, *args, **options):
 
         unused_media = get_unused_media(options.get('exclude') or [])
@@ -44,14 +49,15 @@ class Command(BaseCommand):
 
             # ask user
 
-            if six.moves.input('Are you sure you want to remove %s unused files? (y/N)' % len(unused_media)) != 'Y':
+            if six.moves.input('Are you sure you want to remove %s unused files? (Y/N)' % len(unused_media)) != 'Y':
                 self.stdout.write('Interrupted by user. Exit.')
                 return
 
         for f in unused_media:
             self.stdout.write('Remove %s' % f)
-            os.remove(os.path.join(settings.MEDIA_ROOT, f))
+            os.remove(f)
 
-        remove_empty_dirs()
+        if options.get('remove_empty_dirs'):
+            remove_empty_dirs()
 
         self.stdout.write('Done. %s unused files have been removed' % len(unused_media))

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     install_requires=[
         # add your dependencies here
         # remember to use 'package-name>=x.y.z,<x.y+1.0' notation (this way you get bugfixes)
-        'django>=1.6,<1.11',
+        'django>=1.6,<=1.11',
         'six',
     ],
     extras_require={

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1,19 +1,16 @@
 # -*- coding: utf-8 -*-
-
-import mock
+import os
 import sys
+
 import six
-
-from preggy import expect
 from django.db import models
-from django.core.management import call_command
+from django_unused_media.cleanup import _get_file_fields, _get_all_media, \
+    get_used_media, get_unused_media, _remove_media, remove_unused_media, remove_empty_dirs, MEDIA_ROOT
+from preggy import expect
 
-from django_unused_media.cleanup import _get_file_fields, _get_all_media, get_used_media, get_unused_media, _remove_media, remove_unused_media, remove_empty_dirs
-from django_unused_media.management.commands.cleanup_unused_media import Command
 from .base import BaseTestCase
 from .models import FileFieldsModel, CustomFileldsModel
 from .utils import create_file, create_image, create_file_and_write, exists_media_path
-
 
 _ver = sys.version_info
 
@@ -43,6 +40,10 @@ class TestCleanup(BaseTestCase):
             char_field='test4'
         )
 
+    @staticmethod
+    def __make_abs_path(path):
+        return os.path.join(MEDIA_ROOT, path)
+
     def test_get_file_fields(self):
         file_fields = _get_file_fields()
         expect(file_fields).to_be_instance_of(list).to_length(3)
@@ -58,31 +59,31 @@ class TestCleanup(BaseTestCase):
     def test_get_used_media(self):
         expect(get_used_media())\
             .to_be_instance_of(list).to_length(5)\
-            .to_include(self.model1.file_field.url)\
-            .to_include(self.model1.image_field.url)\
-            .to_include(self.model2.file_field.url)\
-            .to_include(self.model2.image_field.url)\
-            .to_include(self.model3.custom_field.url)
+            .to_include(self.model1.file_field.path)\
+            .to_include(self.model1.image_field.path)\
+            .to_include(self.model2.file_field.path)\
+            .to_include(self.model2.image_field.path)\
+            .to_include(self.model3.custom_field.path)
 
     def test_get_all_media(self):
         expect(_get_all_media())\
             .to_be_instance_of(list).to_length(5)\
-            .to_include(self.model1.file_field.url)\
-            .to_include(self.model1.image_field.url)\
-            .to_include(self.model2.file_field.url)\
-            .to_include(self.model2.image_field.url)\
-            .to_include(self.model3.custom_field.url)
+            .to_include(self.model1.file_field.path)\
+            .to_include(self.model1.image_field.path)\
+            .to_include(self.model2.file_field.path)\
+            .to_include(self.model2.image_field.path)\
+            .to_include(self.model3.custom_field.path)
 
     def test_get_all_media_with_additional(self):
         create_file_and_write(u'file.txt')
         expect(_get_all_media())\
             .to_be_instance_of(list).to_length(6)\
-            .to_include(self.model1.file_field.url)\
-            .to_include(self.model1.image_field.url)\
-            .to_include(self.model2.file_field.url)\
-            .to_include(self.model2.image_field.url)\
-            .to_include(self.model3.custom_field.url)\
-            .to_include(u'file.txt')
+            .to_include(self.model1.file_field.path)\
+            .to_include(self.model1.image_field.path)\
+            .to_include(self.model2.file_field.path)\
+            .to_include(self.model2.image_field.path)\
+            .to_include(self.model3.custom_field.path)\
+            .to_include(self.__make_abs_path(u'file.txt'))
 
     def test_get_all_media_with_exclude(self):
         create_file_and_write(u'file.txt')
@@ -94,15 +95,15 @@ class TestCleanup(BaseTestCase):
         create_file_and_write(u'three.png')
         expect(_get_all_media(['.*', '*.png', 'test.txt']))\
             .to_be_instance_of(list).to_length(7)\
-            .to_include(self.model1.file_field.url)\
-            .to_include(self.model1.image_field.url)\
-            .to_include(self.model2.file_field.url)\
-            .to_include(self.model2.image_field.url)\
-            .to_include(self.model3.custom_field.url)\
-            .to_include(u'file.txt')\
-            .Not.to_include(u'.file2.txt')\
-            .Not.to_include(u'test.txt')\
-            .to_include(u'do_not_exclude/test.txt')
+            .to_include(self.model1.file_field.path)\
+            .to_include(self.model1.image_field.path)\
+            .to_include(self.model2.file_field.path)\
+            .to_include(self.model2.image_field.path)\
+            .to_include(self.model3.custom_field.path)\
+            .to_include(self.__make_abs_path(u'file.txt'))\
+            .Not.to_include(self.__make_abs_path(u'.file2.txt'))\
+            .Not.to_include(self.__make_abs_path(u'test.txt'))\
+            .to_include(self.__make_abs_path(u'do_not_exclude/test.txt'))
 
     def test_get_all_media_with_exclude_folder(self):
         create_file_and_write(u'exclude_dir/file1.txt')
@@ -110,14 +111,14 @@ class TestCleanup(BaseTestCase):
         create_file_and_write(u'file3.txt')
         expect(_get_all_media(['exclude_dir/*']))\
             .to_be_instance_of(list).to_length(6)\
-            .to_include(self.model1.file_field.url)\
-            .to_include(self.model1.image_field.url)\
-            .to_include(self.model2.file_field.url)\
-            .to_include(self.model2.image_field.url)\
-            .to_include(self.model3.custom_field.url)\
-            .to_include(u'file3.txt')\
-            .Not.to_include(u'exclude_dir/file1.txt')\
-            .Not.to_include(u'exclude_dir/file2.txt')
+            .to_include(self.model1.file_field.path)\
+            .to_include(self.model1.image_field.path)\
+            .to_include(self.model2.file_field.path)\
+            .to_include(self.model2.image_field.path)\
+            .to_include(self.model3.custom_field.path)\
+            .to_include(self.__make_abs_path(u'file3.txt'))\
+            .Not.to_include(self.__make_abs_path(u'exclude_dir/file1.txt'))\
+            .Not.to_include(self.__make_abs_path(u'exclude_dir/file2.txt'))
 
     def test_get_unused_media_empty(self):
         expect(get_unused_media()).to_be_empty()
@@ -161,7 +162,7 @@ class TestCleanup(BaseTestCase):
         used_media = get_unused_media()
         expect(used_media).to_be_instance_of(list).to_length(1)
         expect(used_media[0]).to_be_instance_of(six.text_type)
-        expect(used_media[0]).to_equal(u'Тест.txt')
+        expect(used_media[0]).to_equal(self.__make_abs_path(u'Тест.txt'))
 
     def test_relative_path(self):
         FileFieldsModel.objects.create(
@@ -169,4 +170,4 @@ class TestCleanup(BaseTestCase):
         )
         expect(get_used_media()) \
             .to_be_instance_of(list)\
-            .to_include('test_rel_path/file1.txt')
+            .to_include(self.__make_abs_path('test_rel_path/file1.txt'))

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -1,24 +1,24 @@
 # -*- coding: utf-8 -*-
+import os
+import sys
 
 import mock
-import sys
-import six
-
-from preggy import expect
-from django.db import models
 from django.core.management import call_command
-
-from django_unused_media.cleanup import _get_file_fields, _get_all_media, get_used_media, get_unused_media, _remove_media, remove_unused_media, remove_empty_dirs
+from django_unused_media.cleanup import MEDIA_ROOT
 from django_unused_media.management.commands.cleanup_unused_media import Command
-from .base import BaseTestCase
-from .models import FileFieldsModel, CustomFileldsModel
-from .utils import create_file, create_image, create_file_and_write, exists_media_path
+from preggy import expect
 
+from .base import BaseTestCase
+from .utils import create_file_and_write, exists_media_path
 
 _ver = sys.version_info
 
 
 class TestManagementCommand(BaseTestCase):
+    @staticmethod
+    def __make_abs_path(path):
+        return os.path.join(MEDIA_ROOT, path)
+
     def test_command_call(self):
         expect(call_command('cleanup_unused_media', interactive=False)).Not.to_be_an_error()
 
@@ -34,7 +34,7 @@ class TestManagementCommand(BaseTestCase):
         cmd = Command()
         cmd.handle(interactive=False)
         expect(cmd.stdout.getvalue().split('\n'))\
-            .to_include('Remove file.txt')\
+            .to_include('Remove {}'.format(self.__make_abs_path(u'file.txt')))\
             .to_include('Done. 1 unused files have been removed')
 
         expect(exists_media_path('file.txt')).to_be_false()
@@ -57,7 +57,7 @@ class TestManagementCommand(BaseTestCase):
         cmd = Command()
         cmd.handle(interactive=True)
         expect(cmd.stdout.getvalue().split('\n'))\
-            .to_include('Remove file.txt')\
+            .to_include('Remove {}'.format(self.__make_abs_path('file.txt')))\
             .to_include('Done. 1 unused files have been removed')
 
         expect(exists_media_path(u'file.txt')).to_be_false()
@@ -69,7 +69,7 @@ class TestManagementCommand(BaseTestCase):
         cmd = Command()
         cmd.handle(interactive=True)
         expect(cmd.stdout.getvalue().split('\n'))\
-            .to_include('Remove Тест.txt')\
+            .to_include('Remove {}'.format(self.__make_abs_path('Тест.txt')))\
             .to_include('Done. 1 unused files have been removed')
 
         expect(exists_media_path(u'Тест.txt')).to_be_false()

--- a/tox.ini
+++ b/tox.ini
@@ -12,16 +12,19 @@ envlist =
     py27-1.8.X,
     py27-1.9.X,
     py27-1.10.X,
+    py27-1.11.X,
     py35-1.6.X,
     py35-1.7.X,
     py35-1.8.X,
     py35-1.9.X,
     py35-1.10.X,
+    py35-1.11.X,
     pypy-1.6.X,
     pypy-1.7.X,
     pypy-1.8.X,
     pypy-1.9.X,
     pypy-1.10.X
+    pypy-1.11.X
 downloadcache = .tox/_download/
 
 [testenv:py27-1.6.X]
@@ -64,6 +67,14 @@ commands =
 deps =
     Django>=1.10,<1.11
 
+[testenv:py27-1.11.X]
+basepython = python2.7
+commands =
+    make setup
+    make test_no_coverage
+deps =
+    Django==1.11
+
 [testenv:py35-1.6.X]
 basepython = python3.5
 commands =
@@ -104,6 +115,14 @@ commands =
 deps =
     Django>=1.10,<1.11
 
+[testenv:py35-1.11.X]
+basepython = python3.5
+commands =
+    make setup
+    make test_no_coverage
+deps =
+    Django==1.11
+
 [testenv:pypy-1.6.X]
 basepython = pypy
 commands =
@@ -143,3 +162,11 @@ commands =
     make test_no_coverage
 deps =
     Django>=1.10,<1.11
+
+[testenv:pypy-1.11.X]
+basepython = pypy
+commands =
+    make setup
+    make test_no_coverage
+deps =
+    Django==1.11


### PR DESCRIPTION
1. Application should manipulate absolute paths instead of relative paths. The main reason of this is the fact that application **don't working now** with `MEDIA_ROOT` declared as absolute path. Absolute path of `MEDIA_ROOT` usually always used on server, especially on production environments, and it's confused when command **removes all media** when I tried this on project having absolute `MEDIA_ROOT`.
2. `remove_empty_dirs` optional argument added instead of force usage of this behaviour. I added this because not everyone wants to remove empty dirs. Sometimes it can be useful, sometimes not. In my opinion, it would be good to make this behaviour as optional argument.
3. Fixed incorrect option character in command output. This was `y` in output but real character is uppercase - `Y`
4. Tests fixed after replacing relative paths to absolute paths
5. Django v1.11 passed to `install_requires`. I tried this app on my dev and production environments, so it's working well on Django==1.11.