### PR TITLE
improve performance

### DIFF
--- a/django_unused_media/cleanup.py
+++ b/django_unused_media/cleanup.py
@@ -94,10 +94,10 @@ def get_unused_media(exclude=None):
     if not exclude:
         exclude = []
 
-    all_media = _get_all_media(exclude)
-    used_media = get_used_media()
+    all_media = set(_get_all_media(exclude))
+    used_media = set(get_used_media())
 
-    return [x for x in all_media if x not in used_media]
+    return all_media - used_media
 
 
 def _remove_media(files):


### PR DESCRIPTION
Benchmark on EC2 t2.medium instance on media directory with ~50K files:

Before:
```
Dry run. Exit.
3192.42user 0.64system 53:14.07elapsed 99%CPU (0avgtext+0avgdata 1038640maxresident)k
0inputs+23696outputs (0major+278946minor)pagefaults 0swaps
```
After:
```
$ env time ./m cleanup_unused_media -n 
Dry run. Exit.
159.63user 0.59system 2:40.97elapsed 99%CPU (0avgtext+0avgdata 1037740maxresident)k
0inputs+23696outputs (0major+278362minor)pagefaults 0swaps
```