### PR TITLE
Drop obsolete and non working Django

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This package provides management command `cleanup_unused_media` for Django appli
 
     Python 2.7, 3.5, 3.6, PyPy are tested with tox.
     
-    Django 1.6, 1.7, 1.8, 1.9, 1.10, 1.11 are tested with tox.
+    Django 1.9, 1.10, 1.11 are tested with tox.
 
 2.  Add ``django-unused-media`` to ``INSTALLED_APPS``:
     ```python

--- a/django_unused_media/utils.py
+++ b/django_unused_media/utils.py
@@ -18,12 +18,9 @@ def get_file_fields():
         Get all fields which are inherited from FileField
     """
 
-    # get models. Compatibility with 1.6
+    # get models.
 
-    if getattr(apps, 'get_models'):
-        all_models = apps.get_models()
-    else:
-        all_models = models.get_models()
+    all_models = apps.get_models()
 
     # get fields
 

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
     install_requires=[
         # add your dependencies here
         # remember to use 'package-name>=x.y.z,<x.y+1.0' notation (this way you get bugfixes)
-        'django>=1.6',
+        'django>=1.9,<2.0',
         'six',
     ],
     extras_require={

--- a/tox.ini
+++ b/tox.ini
@@ -7,27 +7,15 @@
 
 [tox]
 envlist =
-    py27-1.6.X,
-    py27-1.7.X,
-    py27-1.8.X,
     py27-1.9.X,
     py27-1.10.X,
     py27-1.11.X,
-    py35-1.6.X,
-    py35-1.7.X,
-    py35-1.8.X,
     py35-1.9.X,
     py35-1.10.X,
     py35-1.11.X,
-    py36-1.6.X,
-    py36-1.7.X,
-    py36-1.8.X,
     py36-1.9.X,
     py36-1.10.X,
     py36-1.11.X,
-    pypy-1.6.X,
-    pypy-1.7.X,
-    pypy-1.8.X,
     pypy-1.9.X,
     pypy-1.10.X,
     pypy-1.11.X
@@ -35,30 +23,6 @@ downloadcache = .tox/_download/
 
 [flake8]
 max-line-length = 120
-
-[testenv:py27-1.6.X]
-basepython = python2.7
-commands =
-    make setup
-    make test_no_coverage
-deps =
-    Django>=1.6,<1.7
-
-[testenv:py27-1.7.X]
-basepython = python2.7
-commands =
-    make setup
-    make test_no_coverage
-deps =
-    Django>=1.7,<1.8
-
-[testenv:py27-1.8.X]
-basepython = python2.7
-commands =
-    make setup
-    make test_no_coverage
-deps =
-    Django>=1.8,<1.9
 
 [testenv:py27-1.9.X]
 basepython = python2.7
@@ -84,30 +48,6 @@ commands =
 deps =
     Django>=1.10,<1.12
 
-[testenv:py35-1.6.X]
-basepython = python3.5
-commands =
-    make setup
-    make test_no_coverage
-deps =
-    Django>=1.6,<1.7
-
-[testenv:py35-1.7.X]
-basepython = python3.5
-commands =
-    make setup
-    make test_no_coverage
-deps =
-    Django>=1.7,<1.8
-
-[testenv:py35-1.8.X]
-basepython = python3.5
-commands =
-    make setup
-    make test_no_coverage
-deps =
-    Django>=1.8,<1.9
-
 [testenv:py35-1.9.X]
 basepython = python3.5
 commands =
@@ -123,30 +63,6 @@ commands =
     make test_no_coverage
 deps =
     Django>=1.10,<1.11
-
-[testenv:py36-1.6.X]
-basepython = python3.5
-commands =
-    make setup
-    make test_no_coverage
-deps =
-    Django>=1.6,<1.7
-
-[testenv:py36-1.7.X]
-basepython = python3.6
-commands =
-    make setup
-    make test_no_coverage
-deps =
-    Django>=1.7,<1.8
-
-[testenv:py36-1.8.X]
-basepython = python3.6
-commands =
-    make setup
-    make test_no_coverage
-deps =
-    Django>=1.8,<1.9
 
 [testenv:py36-1.9.X]
 basepython = python3.6
@@ -171,30 +87,6 @@ commands =
     make test_no_coverage
 deps =
     Django>=1.10,<1.12
-
-[testenv:pypy-1.6.X]
-basepython = pypy
-commands =
-    make setup
-    make test_no_coverage
-deps =
-    Django>=1.6,<1.7
-
-[testenv:pypy-1.7.X]
-basepython = pypy
-commands =
-    make setup
-    make test_no_coverage
-deps =
-    Django>=1.7,<1.8
-
-[testenv:pypy-1.8.X]
-basepython = pypy
-commands =
-    make setup
-    make test_no_coverage
-deps =
-    Django>=1.8,<1.9
 
 [testenv:pypy-1.9.X]
 basepython = pypy


### PR DESCRIPTION
Running the tox revealed, that environments with Django < 1.9 do not pass. Since those Django versions are no longer supported, I just removed them.