### PR TITLE
Improve performance

### DIFF
--- a/django_unused_media/cleanup.py
+++ b/django_unused_media/cleanup.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from django.core.validators import EMPTY_VALUES
 
 from .remove import remove_media
-from .utils import append_if_not_exists, get_file_fields
+from .utils import get_file_fields
 
 
 def get_used_media():
@@ -16,7 +16,7 @@ def get_used_media():
         Get media which are still used in models
     """
 
-    media = []
+    media = set()
 
     for field in get_file_fields():
         is_null = {
@@ -32,7 +32,7 @@ def get_used_media():
                 .values_list(field.name, flat=True) \
                 .exclude(**is_empty).exclude(**is_null):
             if value not in EMPTY_VALUES:
-                append_if_not_exists(media, storage.path(value))
+                media.add(storage.path(value))
 
     return media
 
@@ -45,20 +45,17 @@ def get_all_media(exclude=None):
     if not exclude:
         exclude = []
 
-    media = []
+    media = set()
 
     for root, dirs, files in os.walk(six.text_type(settings.MEDIA_ROOT)):
         for name in files:
             path = os.path.abspath(os.path.join(root, name))
             relpath = os.path.relpath(path, settings.MEDIA_ROOT)
-            in_exclude = False
             for e in exclude:
                 if re.match(r'^%s$' % re.escape(e).replace('\\*', '.*'), relpath):
-                    in_exclude = True
                     break
-
-            if not in_exclude:
-                append_if_not_exists(media, path)
+            else:
+                media.add(path)
 
     return media
 
@@ -74,7 +71,7 @@ def get_unused_media(exclude=None):
     all_media = get_all_media(exclude)
     used_media = get_used_media()
 
-    return [x for x in all_media if x not in used_media]
+    return all_media - used_media
 
 
 def remove_unused_media():

--- a/django_unused_media/utils.py
+++ b/django_unused_media/utils.py
@@ -4,15 +4,6 @@ from django.apps import apps
 from django.db import models
 
 
-def append_if_not_exists(lst, item):
-    """
-        Append to the list only if item does not exist yet
-    """
-
-    if item not in lst:
-        lst.append(item)
-
-
 def get_file_fields():
     """
         Get all fields which are inherited from FileField

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -63,7 +63,7 @@ class TestCleanup(BaseTestCase):
 
     def test_get_used_media(self):
         expect(get_used_media())\
-            .to_be_instance_of(list).to_length(5)\
+            .to_be_instance_of(set).to_length(5)\
             .to_include(self.model1.file_field.path)\
             .to_include(self.model1.image_field.path)\
             .to_include(self.model2.file_field.path)\
@@ -72,7 +72,7 @@ class TestCleanup(BaseTestCase):
 
     def test_get_all_media(self):
         expect(get_all_media())\
-            .to_be_instance_of(list).to_length(5)\
+            .to_be_instance_of(set).to_length(5)\
             .to_include(self.model1.file_field.path)\
             .to_include(self.model1.image_field.path)\
             .to_include(self.model2.file_field.path)\
@@ -82,7 +82,7 @@ class TestCleanup(BaseTestCase):
     def test_get_all_media_with_additional(self):
         self._media_create(u'file.txt')
         expect(get_all_media())\
-            .to_be_instance_of(list).to_length(6)\
+            .to_be_instance_of(set).to_length(6)\
             .to_include(self.model1.file_field.path)\
             .to_include(self.model1.image_field.path)\
             .to_include(self.model2.file_field.path)\
@@ -99,7 +99,7 @@ class TestCleanup(BaseTestCase):
         self._media_create(u'two.png')
         self._media_create(u'three.png')
         expect(get_all_media(['.*', '*.png', 'test.txt']))\
-            .to_be_instance_of(list).to_length(7)\
+            .to_be_instance_of(set).to_length(7)\
             .to_include(self.model1.file_field.path)\
             .to_include(self.model1.image_field.path)\
             .to_include(self.model2.file_field.path)\
@@ -115,7 +115,7 @@ class TestCleanup(BaseTestCase):
         self._media_create(u'exclude_dir/file2.txt')
         self._media_create(u'file3.txt')
         expect(get_all_media(['exclude_dir/*']))\
-            .to_be_instance_of(list).to_length(6)\
+            .to_be_instance_of(set).to_length(6)\
             .to_include(self.model1.file_field.path)\
             .to_include(self.model1.image_field.path)\
             .to_include(self.model2.file_field.path)\
@@ -129,7 +129,7 @@ class TestCleanup(BaseTestCase):
     @mock.patch('django_unused_media.cleanup.os.walk', side_effect=win_os_walk)
     def test_get_all_media_win(self, mock_walk, mock_abspath):
         expect(get_all_media())\
-               .to_be_instance_of(list).to_length(1)\
+               .to_be_instance_of(set).to_length(1)\
                .to_include(r'C:\dir\test\file.txt')
 
     def test_get_unused_media_empty(self):
@@ -138,14 +138,14 @@ class TestCleanup(BaseTestCase):
     def test_get_unused_media(self):
         self._media_create(u'notused.txt')
         used_media = get_unused_media()
-        expect(used_media).to_be_instance_of(list).to_length(1)
-        expect(used_media[0]).to_match(r'^.*notused.txt')
+        expect(used_media).to_be_instance_of(set).to_length(1)
+        expect(next(iter(used_media))).to_match(r'^.*notused.txt')
 
     def test_get_unused_media_subfolder(self):
         self._media_create(u'subfolder/notused.txt')
         used_media = get_unused_media()
-        expect(used_media).to_be_instance_of(list).to_length(1)
-        expect(used_media[0]).to_match(r'^.*subfolder/notused.txt$')
+        expect(used_media).to_be_instance_of(set).to_length(1)
+        expect(next(iter(used_media))).to_match(r'^.*subfolder/notused.txt$')
 
     def test_remove_media(self):
         expect(self._media_exists(u'file.txt')).to_be_false()
@@ -181,7 +181,7 @@ class TestCleanup(BaseTestCase):
     def test_ascii_filenames(self):
         self._media_create(u'Тест.txt')
         used_media = get_unused_media()
-        expect(used_media).to_be_instance_of(list).to_length(1)
+        expect(used_media).to_be_instance_of(set).to_length(1)
         expect(used_media[0]).to_be_instance_of(six.text_type)
         expect(used_media[0]).to_equal(self._media_abs_path(u'Тест.txt'))
 
@@ -190,5 +190,5 @@ class TestCleanup(BaseTestCase):
             file_field='./test_rel_path/file1.txt',
         )
         expect(get_used_media()) \
-            .to_be_instance_of(list)\
+            .to_be_instance_of(set)\
             .to_include(self._media_abs_path('test_rel_path/file1.txt'))


### PR DESCRIPTION
This PR significantly reduces algorithm complexity by using sets instead of lists, improving performance enormously. I tried executing it on ~1 mil files and had to ^C it after about 30 minutes. A quick CProfile run later it was clear that the horrible performance was due to lists being used instead of sets. With these changes applied, it now completes in less than 15 seconds. Two tests are failing, but this is also the case with the current master.

**Edit:** Oh, and I also replaced the for loop with "found" variable with a more idiomatic [for/else](http://book.pythontips.com/en/latest/for_-_else.html#else-clause) construct.