### PR TITLE
use base manager for queries to prevent missing objects

### DIFF
--- a/django_unused_media/cleanup.py
+++ b/django_unused_media/cleanup.py
@@ -28,7 +28,7 @@ def get_used_media():
 
         storage = field.storage
 
-        for value in field.model.objects \
+        for value in field.model._base_manager \
                 .values_list(field.name, flat=True) \
                 .exclude(**is_empty).exclude(**is_null):
             if value not in EMPTY_VALUES:


### PR DESCRIPTION
In my case, the default object manager is overwritten so that "deleted" files do not occur in it, but they should also be considered.