### PR TITLE
exclude tests directory from release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         'Programming Language :: Python :: Implementation :: PyPy',
         'Operating System :: OS Independent',
     ],
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests', 'tests.*']),
     include_package_data=True,
     install_requires=[
         # add your dependencies here


### PR DESCRIPTION
The `tests` directory is included in the release, which conflicts with my own `tests` module.

You'll also have to remove `django_unused_media.egg-info` locally for this to work.