### PR TITLE
Fix remove_empty_dirs argument action

### DIFF
--- a/django_unused_media/management/commands/cleanup_unused_media.py
+++ b/django_unused_media/management/commands/cleanup_unused_media.py
@@ -43,7 +43,7 @@ class Command(BaseCommand):
 
         parser.add_argument('--remove-empty-dirs',
                             dest='remove_empty_dirs',
-                            action='store_false',
+                            action='store_true',
                             default=False,
                             help='Remove empty dirs after files cleanup')
 


### PR DESCRIPTION
Bug: combination of `default=False` and `action='store_false'` parameters makes `remove_empty_dirs` argument always `False`
https://github.com/akolpakov/django-unused-media/blob/54a24926cfcf5058186b0480083a5a0d4a1fef47/django_unused_media/management/commands/cleanup_unused_media.py#L44-L48

This condition is always false, so `remove_empty_dirs()` is never called
https://github.com/akolpakov/django-unused-media/blob/54a24926cfcf5058186b0480083a5a0d4a1fef47/django_unused_media/management/commands/cleanup_unused_media.py#L106-L107
This pull request fixes a bug with argparse action setting for `remove_empty_dirs` by setting `action='store_true'`